### PR TITLE
Add EqualsIgnoreCase method to StringExtensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/128
+Your prepared branch: issue-128-1cecfc05
+Your prepared working directory: /tmp/gh-issue-solver-1757758909320
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/128
-Your prepared branch: issue-128-1cecfc05
-Your prepared working directory: /tmp/gh-issue-solver-1757758909320
-
-Proceed.

--- a/csharp/Platform.Collections.Tests/StringTests.cs
+++ b/csharp/Platform.Collections.Tests/StringTests.cs
@@ -21,5 +21,20 @@ namespace Platform.Collections.Tests
             Assert.Equal("hello", "hello'".TrimSingle('\''));
             Assert.Equal("hello", "'hello".TrimSingle('\''));
         }
+
+        [Fact]
+        public static void EqualsIgnoreCaseTest()
+        {
+            Assert.True("Hello".EqualsIgnoreCase("hello"));
+            Assert.True("HELLO".EqualsIgnoreCase("hello"));
+            Assert.True("hello".EqualsIgnoreCase("HELLO"));
+            Assert.True("Hello World".EqualsIgnoreCase("HELLO WORLD"));
+            Assert.True("".EqualsIgnoreCase(""));
+            Assert.False("Hello".EqualsIgnoreCase("World"));
+            Assert.False("Hello".EqualsIgnoreCase("Hell"));
+            Assert.False("Hello".EqualsIgnoreCase(null!));
+            Assert.False(((string?)null).EqualsIgnoreCase("Hello"));
+            Assert.True(((string?)null).EqualsIgnoreCase(null));
+        }
     }
 }

--- a/csharp/Platform.Collections/StringExtensions.cs
+++ b/csharp/Platform.Collections/StringExtensions.cs
@@ -75,6 +75,27 @@ namespace Platform.Collections
 
         /// <summary>
         /// <para>
+        /// Determines whether the specified string equals another string ignoring case.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="@string">
+        /// <para>The string.</para>
+        /// <para></para>
+        /// </param>
+        /// <param name="other">
+        /// <para>The other string to compare with.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>True if the strings are equal ignoring case; otherwise, false.</para>
+        /// <para></para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool EqualsIgnoreCase(this string @string, string other) => string.Equals(@string, other, StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// <para>
         /// Trims the single using the specified string.
         /// </para>
         /// <para></para>


### PR DESCRIPTION
## Summary

Implements the `EqualsIgnoreCase` method for string extensions as requested in issue #128.

- ✅ Added `EqualsIgnoreCase` extension method to `StringExtensions.cs`
- ✅ Uses `StringComparison.OrdinalIgnoreCase` for optimal performance
- ✅ Follows established code style and documentation patterns
- ✅ Includes comprehensive tests covering all scenarios
- ✅ Tests pass successfully

## Test plan

- [x] Unit tests for basic case-insensitive comparison (`"Hello".EqualsIgnoreCase("hello")`)
- [x] Tests for uppercase/lowercase variations 
- [x] Tests for empty strings and null values
- [x] Tests for different string lengths
- [x] All existing tests continue to pass

The implementation follows the project's coding conventions and includes proper XML documentation with the same formatting style as existing methods.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #128