### PR TITLE
Remove unused AllEqualToDefault method (fixes #125)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/125
+Your prepared branch: issue-125-40d83018
+Your prepared working directory: /tmp/gh-issue-solver-1757763294034
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/125
-Your prepared branch: issue-125-40d83018
-Your prepared working directory: /tmp/gh-issue-solver-1757763294034
-
-Proceed.

--- a/csharp/Platform.Collections/ICollectionExtensions.cs
+++ b/csharp/Platform.Collections/ICollectionExtensions.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -27,29 +26,5 @@ namespace Platform.Collections
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsNullOrEmpty<T>(this ICollection<T> collection) => collection == null || collection.Count == 0;
 
-        /// <summary>
-        /// <para>
-        /// Determines whether all equal to default.
-        /// </para>
-        /// <para></para>
-        /// </summary>
-        /// <typeparam name="T">
-        /// <para>The .</para>
-        /// <para></para>
-        /// </typeparam>
-        /// <param name="collection">
-        /// <para>The collection.</para>
-        /// <para></para>
-        /// </param>
-        /// <returns>
-        /// <para>The bool</para>
-        /// <para></para>
-        /// </returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool AllEqualToDefault<T>(this ICollection<T> collection)
-        {
-            var equalityComparer = EqualityComparer<T>.Default;
-            return collection.All(item => equalityComparer.Equals(item, default));
-        }
     }
 }


### PR DESCRIPTION
## Summary

- Removed the `AllEqualToDefault<T>` method from `ICollectionExtensions.cs` 
- Removed unused `System.Linq` import
- Verified no direct usage of this method exists in the codebase

## Rationale

As noted in issue #125, this method should be removed if there's no evidence of direct usage in the code. After thorough analysis of the entire codebase, no references to `AllEqualToDefault` were found outside its declaration.

## Test plan

- [x] Project builds successfully
- [x] Tests pass without issues
- [x] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #125