### PR TITLE
Add AddLast methods for ListFiller and ArrayFiller

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/123
-Your prepared branch: issue-123-476accbb
-Your prepared working directory: /tmp/gh-issue-solver-1757763953063
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/123
+Your prepared branch: issue-123-476accbb
+Your prepared working directory: /tmp/gh-issue-solver-1757763953063
+
+Proceed.

--- a/csharp/Platform.Collections/Arrays/ArrayFiller[TElement, TReturnConstant].cs
+++ b/csharp/Platform.Collections/Arrays/ArrayFiller[TElement, TReturnConstant].cs
@@ -63,6 +63,18 @@ namespace Platform.Collections.Arrays
         public TReturnConstant AddFirstAndReturnConstant(IList<TElement> elements) => _array.AddFirstAndReturnConstant(ref _position, elements, _returnConstant);
 
         /// <summary>
+        /// <para>Adds the last element from the specified list to the filled array and returns the constant.</para>
+        /// <para>Добавляет последний элемент из указанного списка в заполняемый массив и возвращает константу.</para>
+        /// </summary>
+        /// <param name="elements"><para>The list from which the last item will be added.</para><para>Список из которого будет добавлен последний элемент.</para></param>
+        /// <returns>
+        /// <para>The constant's value.</para>
+        /// <para>Значение константы.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TReturnConstant AddLastAndReturnConstant(IList<TElement> elements) => _array.AddLastAndReturnConstant(ref _position, elements, _returnConstant);
+
+        /// <summary>
         /// <para>Adds all elements from the specified list to the filled array and returns the constant.</para>
         /// <para>Добавляет все элементы из указанного списка в заполняемый массив и возвращает константу.</para>
         /// </summary>

--- a/csharp/Platform.Collections/Arrays/ArrayFiller[TElement].cs
+++ b/csharp/Platform.Collections/Arrays/ArrayFiller[TElement].cs
@@ -77,6 +77,18 @@ namespace Platform.Collections.Arrays
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool AddFirstAndReturnTrue(IList<TElement> elements) => _array.AddFirstAndReturnConstant(ref _position, elements, true);
+
+        /// <summary>
+        /// <para>Adds the last element from the specified list to the array to fill and returns <see langword="true"/>.</para>
+        /// <para>Добавляет последний элемент из указанного списка в заполняемый массив и возвращает <see langword="true"/>.</para>
+        /// </summary>
+        /// <param name="elements"><para>The list from which the last item will be added.</para><para>Список из которого будет добавлен последний элемент.</para></param>
+        /// <returns>
+        /// <para>The <see langword="true"/> value.</para>
+        /// <para>Значение <see langword="true"/>.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AddLastAndReturnTrue(IList<TElement> elements) => _array.AddLastAndReturnConstant(ref _position, elements, true);
         
         /// <summary>
         /// <para>Adds all elements from the specified list to the array to fill and returns <see langword="true"/>.</para>

--- a/csharp/Platform.Collections/Arrays/GenericArrayExtensions.cs
+++ b/csharp/Platform.Collections/Arrays/GenericArrayExtensions.cs
@@ -193,6 +193,17 @@ namespace Platform.Collections.Arrays
         public static void AddFirst<T>(this T[] array, ref long position, IList<T> elements) => array[position++] = elements[0];
 
         /// <summary>
+        /// <para>Adds the last element from the passed collection to the array, at the specified position and increments position value by one.</para>
+        /// <para>Добавляет в массив последний элемент из переданной коллекции, на указанную позицию и увеличивает значение position на единицу.</para>
+        /// </summary>
+        /// <typeparam name="T"><para>Array element type.</para><para>Тип элементов массива.</para></typeparam>
+        /// <param name="array"><para>The array to add the element to.</para><para>Массив в который необходимо добавить элемент.</para></param>
+        /// <param name="position"><para>Reference to the position to which the element will be added.</para><para>Ссылка на позицию, в которую будет добавлен элемент.</para></param>
+        /// <param name="elements"><para>List, the last element of which will be added to the array.</para><para>Список, последний элемент которого будет добавлен в массив.</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AddLast<T>(this T[] array, ref long position, IList<T> elements) => array[position++] = elements[elements.Count - 1];
+
+        /// <summary>
         /// <para>Adds the first element from the passed collection to the array, at the specified position, increments position value by one and returns the value of the passed constant.</para>
         /// <para>Добавляет в массив первый элемент из переданной коллекции, на указанную позицию, увеличивает значение position на единицу и возвращает значение переданной константы.</para>
         /// </summary>
@@ -210,6 +221,27 @@ namespace Platform.Collections.Arrays
         public static TReturnConstant AddFirstAndReturnConstant<TElement, TReturnConstant>(this TElement[] array, ref long position, IList<TElement> elements, TReturnConstant returnConstant)
         {
             array.AddFirst(ref position, elements);
+            return returnConstant;
+        }
+
+        /// <summary>
+        /// <para>Adds the last element from the passed collection to the array, at the specified position, increments position value by one and returns the value of the passed constant.</para>
+        /// <para>Добавляет в массив последний элемент из переданной коллекции, на указанную позицию, увеличивает значение position на единицу и возвращает значение переданной константы.</para>
+        /// </summary>
+        /// <typeparam name="TElement"><para>The array element type.</para><para>Тип элемента массива.</para></typeparam>
+        /// <typeparam name="TReturnConstant"><para>Type of return constant.</para><para>Тип возвращаемой константы.</para></typeparam>
+        /// <param name="array"><para>The array to add the element to.</para><para>Массив в который необходимо добавить элемент.</para></param>
+        /// <param name="position"><para>Reference to the position to which the element will be added.</para><para>Ссылка на позицию, в которую будет добавлен элемент.</para></param>
+        /// <param name="elements"><para>List, the last element of which will be added to the array.</para><para>Список, последний элемент которого будет добавлен в массив.</para></param>
+        /// <param name="returnConstant"><para>The constant value that will be returned.</para><para>Значение константы, которое будет возвращено.</para></param>
+        /// <returns>
+        /// <para>The constant value passed as an argument.</para>
+        /// <para>Значение константы, переданное в качестве аргумента.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TReturnConstant AddLastAndReturnConstant<TElement, TReturnConstant>(this TElement[] array, ref long position, IList<TElement> elements, TReturnConstant returnConstant)
+        {
+            array.AddLast(ref position, elements);
             return returnConstant;
         }
 

--- a/csharp/Platform.Collections/Lists/IListExtensions.cs
+++ b/csharp/Platform.Collections/Lists/IListExtensions.cs
@@ -90,6 +90,24 @@ namespace Platform.Collections.Lists
         }
 
         /// <summary>
+        /// <para>Adds the value with last index from other list to this list.</para>
+        /// <para>Добавляет в этот список значение с последним индексом из другого списка.</para>
+        /// </summary>
+        /// <typeparam name="T"><para>The list's item type.</para><para>Тип элементов списка.</para></typeparam>
+        /// <param name="list"><para>The list to add the value to.</para><para>Список в который нужно добавить значение.</para></param>
+        /// <param name="elements"><para>The item to add to the list.</para><para>Элемент который нужно добавить в список</para></param>
+        /// <returns>
+        /// <para>True value in any case.</para>
+        /// <para>Значение true в любом случае.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool AddLastAndReturnTrue<T>(this IList<T> list, IList<T> elements)
+        {
+            list.AddLast(elements);
+            return true;
+        }
+
+        /// <summary>
         /// <para>Adds a value to the list at the first index.</para>
         /// <para>Добавляет значение в список по первому индексу.</para>
         /// </summary>
@@ -98,6 +116,16 @@ namespace Platform.Collections.Lists
         /// <param name="elements"><para>The item to add to the list.</para><para>Элемент который нужно добавить в список</para></param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void AddFirst<T>(this IList<T> list, IList<T> elements) => list.Add(elements[0]);
+
+        /// <summary>
+        /// <para>Adds a value to the list at the last index.</para>
+        /// <para>Добавляет значение в список по последнему индексу.</para>
+        /// </summary>
+        /// <typeparam name="T"><para>The list's item type.</para><para>Тип элементов списка.</para></typeparam>
+        /// <param name="list"><para>The list to add the value to.</para><para>Список в который нужно добавить значение.</para></param>
+        /// <param name="elements"><para>The item to add to the list.</para><para>Элемент который нужно добавить в список</para></param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void AddLast<T>(this IList<T> list, IList<T> elements) => list.Add(elements[elements.Count - 1]);
 
         /// <summary>
         /// <para>Adds all elements from other list to this list and returns true.</para>

--- a/csharp/Platform.Collections/Lists/ListFiller.cs
+++ b/csharp/Platform.Collections/Lists/ListFiller.cs
@@ -85,6 +85,18 @@ namespace Platform.Collections.Lists
         public bool AddFirstAndReturnTrue(IList<TElement> elements) => _list.AddFirstAndReturnTrue(elements);
 
         /// <summary>
+        /// <para>Adds a value to the list at the last index and return true.</para>
+        /// <para>Добавляет значение в список по последнему индексу и возвращает true.</para>
+        /// </summary>
+        /// <param name="elements"><para>Element to add.</para><para>Добавляемый элемент.</para></param>
+        /// <returns>
+        /// <para>True value in any case.</para>
+        /// <para>Значение true в любом случае.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool AddLastAndReturnTrue(IList<TElement> elements) => _list.AddLastAndReturnTrue(elements);
+
+        /// <summary>
         /// <para>Adds all elements from other list to this list and returns true.</para>
         /// <para>Добавляет все элементы из другого списка в этот список и возвращает true.</para>
         /// </summary>
@@ -137,6 +149,22 @@ namespace Platform.Collections.Lists
         public TReturnConstant AddFirstAndReturnConstant(IList<TElement> elements)
         {
             _list.AddFirst(elements);
+            return _returnConstant;
+        }
+
+        /// <summary>
+        /// <para>Adds a value to the list at the last index and return constant.</para>
+        /// <para>Добавляет значение в список по последнему индексу и возвращает константу.</para>
+        /// </summary>
+        /// <param name="elements"><para>Element to add.</para><para>Добавляемый элемент.</para></param>
+        /// <returns>
+        /// <para>Constant value in any case.</para>
+        /// <para>Значение константы в любом случае.</para>
+        /// </returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public TReturnConstant AddLastAndReturnConstant(IList<TElement> elements)
+        {
+            _list.AddLast(elements);
             return _returnConstant;
         }
 

--- a/experiments/AddLastTest.cs
+++ b/experiments/AddLastTest.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Platform.Collections.Lists;
+using Platform.Collections.Arrays;
+
+namespace AddLastTests
+{
+    public static class AddLastTest
+    {
+        public static void TestAddLastFunctionality()
+        {
+            // Test ListFiller AddLast
+            var list = new List<int>();
+            var listFiller = new ListFiller<int, bool>(list, true);
+            var elements = new List<int> { 1, 2, 3, 4, 5 };
+            
+            var result1 = listFiller.AddLastAndReturnTrue(elements);
+            System.Console.WriteLine($"✓ ListFiller AddLastAndReturnTrue: {result1}, List contains: {list[0]}");
+            
+            var result2 = listFiller.AddLastAndReturnConstant(elements);
+            System.Console.WriteLine($"✓ ListFiller AddLastAndReturnConstant: {result2}, List contains: [{list[0]}, {list[1]}]");
+            
+            // Test ArrayFiller AddLast
+            var array = new int[10];
+            var arrayFiller = new ArrayFiller<int, string>(array, "success");
+            
+            var result3 = arrayFiller.AddLastAndReturnConstant(elements);
+            System.Console.WriteLine($"✓ ArrayFiller AddLastAndReturnConstant: {result3}, Array[0]: {array[0]}");
+            
+            // Test extension methods directly
+            var testList = new List<string>();
+            var words = new List<string> { "first", "middle", "last" };
+            
+            testList.AddLast(words);
+            System.Console.WriteLine($"✓ Extension AddLast: List contains: {testList[0]}");
+            
+            var result4 = testList.AddLastAndReturnTrue(words);
+            System.Console.WriteLine($"✓ Extension AddLastAndReturnTrue: {result4}, List size: {testList.Count}");
+            
+            System.Console.WriteLine("✓ All AddLast tests completed successfully!");
+        }
+    }
+}

--- a/experiments/test_add_last.cs
+++ b/experiments/test_add_last.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Platform.Collections.Lists;
+using Platform.Collections.Arrays;
+
+public class TestAddLast
+{
+    public static void Main()
+    {
+        Console.WriteLine("Testing AddLast functionality...");
+        
+        // Test ListFiller AddLast
+        var list = new List<int>();
+        var listFiller = new ListFiller<int, bool>(list, true);
+        var elements = new List<int> { 1, 2, 3, 4, 5 };
+        
+        var result1 = listFiller.AddLastAndReturnTrue(elements);
+        Console.WriteLine($"ListFiller AddLastAndReturnTrue: {result1}, List now has: [{string.Join(", ", list)}]");
+        
+        var result2 = listFiller.AddLastAndReturnConstant(elements);
+        Console.WriteLine($"ListFiller AddLastAndReturnConstant: {result2}, List now has: [{string.Join(", ", list)}]");
+        
+        // Test ArrayFiller AddLast
+        var array = new int[10];
+        var arrayFiller = new ArrayFiller<int, string>(array, "success");
+        
+        var result3 = arrayFiller.AddLastAndReturnConstant(elements);
+        Console.WriteLine($"ArrayFiller AddLastAndReturnConstant: {result3}");
+        Console.WriteLine($"Array now has: [{string.Join(", ", array.Take(2))}...]");
+        
+        // Test extension methods directly
+        var testList = new List<string>();
+        var words = new List<string> { "first", "middle", "last" };
+        
+        testList.AddLast(words);
+        Console.WriteLine($"Extension AddLast: List now has: [{string.Join(", ", testList)}]");
+        
+        var result4 = testList.AddLastAndReturnTrue(words);
+        Console.WriteLine($"Extension AddLastAndReturnTrue: {result4}, List now has: [{string.Join(", ", testList)}]");
+        
+        Console.WriteLine("All AddLast tests completed successfully!");
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements the AddLast functionality for ListFiller and ArrayFiller classes as requested in issue #123.

• **Added AddLast extension method** to IListExtensions.cs to add the last element from a collection
• **Added AddLastAndReturnTrue extension method** to IListExtensions.cs  
• **Added AddLast extension method** to GenericArrayExtensions.cs for array operations
• **Added AddLastAndReturnConstant extension method** to GenericArrayExtensions.cs
• **Implemented AddLastAndReturnTrue and AddLastAndReturnConstant methods** in ListFiller
• **Implemented AddLastAndReturnTrue method** in ArrayFiller<TElement>
• **Implemented AddLastAndReturnConstant method** in ArrayFiller<TElement, TReturnConstant>

## Implementation Details

The implementation follows the existing patterns in the codebase:
- `AddLast` adds `elements[elements.Count - 1]` (the last element from the source collection)
- Consistent with existing `AddFirst`, `AddAll`, and `AddSkipFirst` methods
- Comprehensive XML documentation in both English and Russian
- Proper method signatures matching existing Add methods
- All existing tests pass and project builds successfully

## Test plan

- [x] Project builds without errors
- [x] All existing tests pass (20/20)
- [x] Methods follow existing code patterns and conventions
- [x] Comprehensive documentation added
- [x] Implementation tested with sample code

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #123