### PR TITLE
Fix IndexOutOfRangeException when using negative indices in array extensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/122
+Your prepared branch: issue-122-c8ce967d
+Your prepared working directory: /tmp/gh-issue-solver-1757764784363
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/122
-Your prepared branch: issue-122-c8ce967d
-Your prepared working directory: /tmp/gh-issue-solver-1757764784363
-
-Proceed.

--- a/csharp/Platform.Collections.Tests/ArrayTests.cs
+++ b/csharp/Platform.Collections.Tests/ArrayTests.cs
@@ -20,5 +20,29 @@ namespace Platform.Collections.Tests
             Assert.False(array.TryGetElement(10, out element));
             Assert.Equal(0, element);
         }
+
+        [Fact]
+        public void GetElementWithNegativeIndexTest()
+        {
+            var array = new int[] { 1, 2, 3 };
+            
+            // Test GetElementOrDefault with negative index
+            Assert.Equal(0, array.GetElementOrDefault(-1));
+            Assert.Equal(0, array.GetElementOrDefault(-10));
+            
+            // Test TryGetElement with negative index
+            Assert.False(array.TryGetElement(-1, out int element));
+            Assert.Equal(0, element);
+            Assert.False(array.TryGetElement(-10, out element));
+            Assert.Equal(0, element);
+            
+            // Test long versions
+            Assert.Equal(0, array.GetElementOrDefault(-1L));
+            Assert.Equal(0, array.GetElementOrDefault(-10L));
+            Assert.False(array.TryGetElement(-1L, out element));
+            Assert.Equal(0, element);
+            Assert.False(array.TryGetElement(-10L, out element));
+            Assert.Equal(0, element);
+        }
     }
 }

--- a/csharp/Platform.Collections/Arrays/GenericArrayExtensions.cs
+++ b/csharp/Platform.Collections/Arrays/GenericArrayExtensions.cs
@@ -19,7 +19,7 @@ namespace Platform.Collections.Arrays
         /// <param name="index"><para>Number type int to compare.</para><para>Число типа int для сравнения.</para></param>
         /// <returns><para>Array element or default value.</para><para>Элемент массива или же значение по умолчанию.</para></returns>        
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T GetElementOrDefault<T>(this T[] array, int index) => array != null && array.Length > index ? array[index] : default;
+        public static T GetElementOrDefault<T>(this T[] array, int index) => array != null && index >= 0 && array.Length > index ? array[index] : default;
         
         /// <summary>
         /// <para>Сhecks whether the array exists, if so, checks the array length using the  index variable type long, and if the array length is greater than the index - return array[index], otherwise - default value.</para>
@@ -30,7 +30,7 @@ namespace Platform.Collections.Arrays
         /// <param name="index"><para>Number type long to compare.</para><para>Число типа long для сравнения.</para></param>
         /// <returns><para>Array element or default value.</para><para>Элемент массива или же значение по умолчанию.</para></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T GetElementOrDefault<T>(this T[] array, long index) => array != null && array.LongLength > index ? array[index] : default;
+        public static T GetElementOrDefault<T>(this T[] array, long index) => array != null && index >= 0 && array.LongLength > index ? array[index] : default;
 
         /// <summary>
         /// <para>Checks whether the array exist, if so, checks the array length using the index varible type int, and if the array length is greater than the index, set the element variable to array[index] and return <see langword="true"/>.</para>
@@ -44,7 +44,7 @@ namespace Platform.Collections.Arrays
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryGetElement<T>(this T[] array, int index, out T element)
         {
-            if (array != null && array.Length > index)
+            if (array != null && index >= 0 && array.Length > index)
             {
                 element = array[index];
                 return true;
@@ -68,7 +68,7 @@ namespace Platform.Collections.Arrays
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryGetElement<T>(this T[] array, long index, out T element)
         {
-            if (array != null && array.LongLength > index)
+            if (array != null && index >= 0 && array.LongLength > index)
             {
                 element = array[index];
                 return true;

--- a/experiments/ExperimentApp.csproj
+++ b/experiments/ExperimentApp.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../csharp/Platform.Collections/Platform.Collections.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/experiments/NegativeIndexExperiment.cs
+++ b/experiments/NegativeIndexExperiment.cs
@@ -1,0 +1,49 @@
+using System;
+using Platform.Collections.Arrays;
+
+// This experiment demonstrates that the fix works correctly
+public class Program
+{
+    public static void Main()
+    {
+        var array = new int[] { 1, 2, 3 };
+        
+        Console.WriteLine("Testing GetElementOrDefault with negative index:");
+        
+        // Before fix: This would throw IndexOutOfRangeException
+        // After fix: Returns default value (0)
+        var result1 = array.GetElementOrDefault(-1);
+        Console.WriteLine($"GetElementOrDefault(-1) = {result1}"); // Should be 0
+        
+        var result2 = array.GetElementOrDefault(-10);
+        Console.WriteLine($"GetElementOrDefault(-10) = {result2}"); // Should be 0
+        
+        Console.WriteLine("\nTesting TryGetElement with negative index:");
+        
+        // Before fix: This would throw IndexOutOfRangeException 
+        // After fix: Returns false and sets element to default
+        bool success1 = array.TryGetElement(-1, out int element1);
+        Console.WriteLine($"TryGetElement(-1, out element) = {success1}, element = {element1}"); // Should be false, 0
+        
+        bool success2 = array.TryGetElement(-10, out int element2);
+        Console.WriteLine($"TryGetElement(-10, out element) = {success2}, element = {element2}"); // Should be false, 0
+        
+        Console.WriteLine("\nTesting with long versions:");
+        
+        var result3 = array.GetElementOrDefault(-1L);
+        Console.WriteLine($"GetElementOrDefault(-1L) = {result3}"); // Should be 0
+        
+        bool success3 = array.TryGetElement(-1L, out int element3);
+        Console.WriteLine($"TryGetElement(-1L, out element) = {success3}, element = {element3}"); // Should be false, 0
+        
+        Console.WriteLine("\nTesting with valid indices (should still work):");
+        
+        var result4 = array.GetElementOrDefault(1);
+        Console.WriteLine($"GetElementOrDefault(1) = {result4}"); // Should be 2
+        
+        bool success4 = array.TryGetElement(1, out int element4);
+        Console.WriteLine($"TryGetElement(1, out element) = {success4}, element = {element4}"); // Should be true, 2
+        
+        Console.WriteLine("\nAll tests completed without exceptions!");
+    }
+}


### PR DESCRIPTION
## 🐛 Bug Fix

This pull request fixes issue #122 where negative indices passed to array extension methods would cause `IndexOutOfRangeException`.

### 📋 Issue Reference
Fixes #122

### 🔍 Root Cause
The issue was in the `GetElementOrDefault` and `TryGetElement` methods in `GenericArrayExtensions.cs`. The methods only checked:
```csharp
array != null && array.Length > index
```

When `index < 0`, this condition would still be `true` (since array length is always positive), but accessing `array[index]` would throw `IndexOutOfRangeException`.

### ✅ Solution
Added proper bounds checking by including `index >= 0` in all affected methods:

**Before:**
```csharp
array != null && array.Length > index
```

**After:**
```csharp
array != null && index >= 0 && array.Length > index
```

### 🔧 Methods Fixed
- `GetElementOrDefault<T>(this T[] array, int index)`
- `GetElementOrDefault<T>(this T[] array, long index)` 
- `TryGetElement<T>(this T[] array, int index, out T element)`
- `TryGetElement<T>(this T[] array, long index, out T element)`

### 🧪 Testing
- Added comprehensive test `GetElementWithNegativeIndexTest` to verify negative indices behavior
- Added experiment demonstrating the fix works correctly
- All existing tests continue to pass
- Methods now gracefully handle negative indices by returning default values

### 📊 Test Results
```
Test Run Successful.
Total tests: 21
     Passed: 21
```

The fix ensures that:
- Negative indices return default values instead of throwing exceptions
- `TryGetElement` returns `false` with default element for negative indices
- All positive valid/invalid indices continue to work as before

---
🤖 Generated with [Claude Code](https://claude.ai/code)