### PR TITLE
Make all readonly fields public

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/120
+Your prepared branch: issue-120-059a0a2f
+Your prepared working directory: /tmp/gh-issue-solver-1757771036158
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/120
-Your prepared branch: issue-120-059a0a2f
-Your prepared working directory: /tmp/gh-issue-solver-1757771036158
-
-Proceed.

--- a/csharp/Platform.Collections/Arrays/ArrayFiller[TElement, TReturnConstant].cs
+++ b/csharp/Platform.Collections/Arrays/ArrayFiller[TElement, TReturnConstant].cs
@@ -17,7 +17,7 @@ namespace Platform.Collections.Arrays
         /// </para>
         /// <para></para>
         /// </summary>
-        protected readonly TReturnConstant _returnConstant;
+        public readonly TReturnConstant _returnConstant;
 
         /// <summary>
         /// <para>Initializes a new instance of the <see cref="ArrayFiller"/> class using the specified array, the offset from which filling will start and the constant returned when elements are being filled.</para>

--- a/csharp/Platform.Collections/Arrays/ArrayFiller[TElement].cs
+++ b/csharp/Platform.Collections/Arrays/ArrayFiller[TElement].cs
@@ -16,7 +16,7 @@ namespace Platform.Collections.Arrays
         /// </para>
         /// <para></para>
         /// </summary>
-        protected readonly TElement[] _array;
+        public readonly TElement[] _array;
         /// <summary>
         /// <para>
         /// The position.

--- a/csharp/Platform.Collections/Arrays/ArrayPool[T].cs
+++ b/csharp/Platform.Collections/Arrays/ArrayPool[T].cs
@@ -32,8 +32,8 @@ namespace Platform.Collections.Arrays
         /// <para></para>
         /// </summary>
         internal static ArrayPool<T> ThreadInstance => _threadInstance ?? (_threadInstance = new ArrayPool<T>());
-        private readonly int _maxArraysPerSize;
-        private readonly Dictionary<long, Stack<T[]>> _pool = new Dictionary<long, Stack<T[]>>(ArrayPool.DefaultSizesAmount);
+        public readonly int _maxArraysPerSize;
+        public readonly Dictionary<long, Stack<T[]>> _pool = new Dictionary<long, Stack<T[]>>(ArrayPool.DefaultSizesAmount);
 
         /// <summary>
         /// <para>Initializes a new instance of the ArrayPool class using the specified maximum number of arrays per size.</para>

--- a/csharp/Platform.Collections/BitString.cs
+++ b/csharp/Platform.Collections/BitString.cs
@@ -21,7 +21,7 @@ namespace Platform.Collections
     /// </remarks>
     public class BitString : IEquatable<BitString>
     {
-        private static readonly byte[][] _bitsSetIn16Bits;
+        public static readonly byte[][] _bitsSetIn16Bits;
         private long[] _array;
         private long _length;
         private long _minPositiveWord;

--- a/csharp/Platform.Collections/Lists/ListFiller.cs
+++ b/csharp/Platform.Collections/Lists/ListFiller.cs
@@ -17,14 +17,14 @@ namespace Platform.Collections.Lists
         /// </para>
         /// <para></para>
         /// </summary>
-        protected readonly List<TElement> _list;
+        public readonly List<TElement> _list;
         /// <summary>
         /// <para>
         /// The return constant.
         /// </para>
         /// <para></para>
         /// </summary>
-        protected readonly TReturnConstant _returnConstant;
+        public readonly TReturnConstant _returnConstant;
 
         /// <summary>
         /// <para>Initializes a new instance of the ListFiller class.</para>

--- a/csharp/Platform.Collections/Segments/Walkers/AllSegmentsWalkerBase[T, TSegment].cs
+++ b/csharp/Platform.Collections/Segments/Walkers/AllSegmentsWalkerBase[T, TSegment].cs
@@ -15,7 +15,7 @@ namespace Platform.Collections.Segments.Walkers
     public abstract class AllSegmentsWalkerBase<T, TSegment> : AllSegmentsWalkerBase
         where TSegment : Segment<T>
     {
-        private readonly int _minimumStringSegmentLength;
+        public readonly int _minimumStringSegmentLength;
 
         /// <summary>
         /// <para>

--- a/csharp/Platform.Collections/Segments/Walkers/DictionaryBasedDuplicateSegmentsWalkerBase[T, Segment].cs
+++ b/csharp/Platform.Collections/Segments/Walkers/DictionaryBasedDuplicateSegmentsWalkerBase[T, Segment].cs
@@ -23,7 +23,7 @@ namespace Platform.Collections.Segments.Walkers
         /// <para></para>
         /// </summary>
         public static readonly bool DefaultResetDictionaryOnEachWalk;
-        private readonly bool _resetDictionaryOnEachWalk;
+        public readonly bool _resetDictionaryOnEachWalk;
         /// <summary>
         /// <para>
         /// The dictionary.

--- a/csharp/Platform.Collections/Sets/SetFiller.cs
+++ b/csharp/Platform.Collections/Sets/SetFiller.cs
@@ -19,14 +19,14 @@ namespace Platform.Collections.Sets
         /// </para>
         /// <para></para>
         /// </summary>
-        protected readonly ISet<TElement> _set;
+        public readonly ISet<TElement> _set;
         /// <summary>
         /// <para>
         /// The return constant.
         /// </para>
         /// <para></para>
         /// </summary>
-        protected readonly TReturnConstant _returnConstant;
+        public readonly TReturnConstant _returnConstant;
 
         /// <summary>
         /// <para>


### PR DESCRIPTION
## Summary
- Made all readonly fields public across the codebase as requested in issue #120
- Updated access modifiers from `protected` or `private` to `public` for readonly fields in:
  - `ListFiller<TElement, TReturnConstant>`: `_list` and `_returnConstant` fields
  - `SetFiller<TElement, TReturnConstant>`: `_set` and `_returnConstant` fields  
  - `ArrayFiller<TElement>`: `_array` field
  - `ArrayFiller<TElement, TReturnConstant>`: `_returnConstant` field
  - `ArrayPool<T>`: `_maxArraysPerSize` and `_pool` fields
  - `AllSegmentsWalkerBase<T, TSegment>`: `_minimumStringSegmentLength` field
  - `DictionaryBasedDuplicateSegmentsWalkerBase<T, TSegment>`: `_resetDictionaryOnEachWalk` field
  - `BitString`: `_bitsSetIn16Bits` static field

## Test plan
- [x] All existing tests pass successfully
- [x] No breaking changes introduced
- [x] Fields maintain their readonly nature, only access level changed

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #120