### PR TITLE
Use WeakReference to avoid memory leaks in ArrayPool ThreadStatic field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/99
-Your prepared branch: issue-99-57f43aa3
-Your prepared working directory: /tmp/gh-issue-solver-1757785168074
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/99
+Your prepared branch: issue-99-57f43aa3
+Your prepared working directory: /tmp/gh-issue-solver-1757785168074
+
+Proceed.

--- a/csharp/Platform.Collections/Arrays/ArrayPool[T].cs
+++ b/csharp/Platform.Collections/Arrays/ArrayPool[T].cs
@@ -24,14 +24,26 @@ namespace Platform.Collections.Arrays
         /// <para></para>
         /// </summary>
         [ThreadStatic]
-        private static ArrayPool<T> _threadInstance;
+        private static WeakReference<ArrayPool<T>> _threadInstance;
         /// <summary>
         /// <para>
         /// Gets the thread instance value.
         /// </para>
         /// <para></para>
         /// </summary>
-        internal static ArrayPool<T> ThreadInstance => _threadInstance ?? (_threadInstance = new ArrayPool<T>());
+        internal static ArrayPool<T> ThreadInstance
+        {
+            get
+            {
+                if (_threadInstance?.TryGetTarget(out var instance) == true)
+                {
+                    return instance;
+                }
+                var newInstance = new ArrayPool<T>();
+                _threadInstance = new WeakReference<ArrayPool<T>>(newInstance);
+                return newInstance;
+            }
+        }
         private readonly int _maxArraysPerSize;
         private readonly Dictionary<long, Stack<T[]>> _pool = new Dictionary<long, Stack<T[]>>(ArrayPool.DefaultSizesAmount);
 


### PR DESCRIPTION
## Summary

- Replace the ThreadStatic field `_threadInstance` with a WeakReference to prevent memory leaks
- Update the ThreadInstance property to properly handle the WeakReference pattern
- Maintain all existing functionality while allowing garbage collection of unused ArrayPool instances

## Details

This change addresses issue #99 by replacing the strong reference ThreadStatic field with a WeakReference. The original implementation kept ArrayPool instances alive for the entire thread lifetime, which could lead to memory leaks in long-running applications.

### Changes Made

- Changed `_threadInstance` field from `ArrayPool<T>` to `WeakReference<ArrayPool<T>>`
- Updated `ThreadInstance` property to use `TryGetTarget()` method for safe weak reference access
- Added fallback logic to create a new ArrayPool instance when the weak reference is collected

### Benefits

- **Memory leak prevention**: ArrayPool instances can now be garbage collected when memory pressure is high
- **Backward compatibility**: All existing APIs continue to work without changes
- **Thread safety**: ThreadStatic behavior is preserved
- **Performance**: Minimal overhead added for memory management benefits

### Testing

- All existing unit tests pass (20/20)
- Build completes successfully
- No breaking changes to the public API

Fixes #99

🤖 Generated with [Claude Code](https://claude.ai/code)