### PR TITLE
Fix ArrayPool Resize method when old and new sizes are the same

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/96
-Your prepared branch: issue-96-c549fe2e
-Your prepared working directory: /tmp/gh-issue-solver-1757786216276
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/96
+Your prepared branch: issue-96-c549fe2e
+Your prepared working directory: /tmp/gh-issue-solver-1757786216276
+
+Proceed.

--- a/csharp/Platform.Collections.Tests/ArrayPoolTests.cs
+++ b/csharp/Platform.Collections.Tests/ArrayPoolTests.cs
@@ -1,0 +1,117 @@
+using Xunit;
+using Platform.Collections.Arrays;
+
+namespace Platform.Collections.Tests
+{
+    public class ArrayPoolTests
+    {
+        [Fact]
+        public void Resize_WhenSizesAreSame_ShouldReturnSameObject()
+        {
+            var pool = new ArrayPool<int>();
+            var originalArray = pool.AllocateDisposable(5);
+            int[] arr = originalArray;
+            
+            // Fill with test data
+            for (int i = 0; i < arr.Length; i++)
+            {
+                arr[i] = i + 1;
+            }
+            
+            // Resize to the same size
+            var resizedArray = pool.Resize(originalArray, 5);
+            int[] newArr = resizedArray;
+            
+            // Should be the same object reference
+            Assert.True(object.ReferenceEquals(arr, newArr));
+            
+            // Data should remain unchanged
+            Assert.Equal(new int[] { 1, 2, 3, 4, 5 }, newArr);
+            
+            resizedArray.Dispose();
+        }
+        
+        [Fact]
+        public void Resize_WhenSizesDiffer_ShouldCreateNewObject()
+        {
+            var pool = new ArrayPool<int>();
+            var originalArray = pool.AllocateDisposable(5);
+            int[] arr = originalArray;
+            
+            // Fill with test data
+            for (int i = 0; i < arr.Length; i++)
+            {
+                arr[i] = i + 1;
+            }
+            
+            // Resize to different size (smaller)
+            var resizedArray = pool.Resize(originalArray, 3);
+            int[] newArr = resizedArray;
+            
+            // Should be different object reference
+            Assert.False(object.ReferenceEquals(arr, newArr));
+            
+            // Data should be copied (first 3 elements)
+            Assert.Equal(new int[] { 1, 2, 3 }, newArr);
+            
+            resizedArray.Dispose();
+        }
+        
+        [Fact]
+        public void Resize_WhenResizingToLarger_ShouldCopyAllOriginalData()
+        {
+            var pool = new ArrayPool<int>();
+            var originalArray = pool.AllocateDisposable(3);
+            int[] arr = originalArray;
+            
+            // Fill with test data
+            for (int i = 0; i < arr.Length; i++)
+            {
+                arr[i] = i + 1;
+            }
+            
+            // Resize to larger size
+            var resizedArray = pool.Resize(originalArray, 5);
+            int[] newArr = resizedArray;
+            
+            // Should be different object reference
+            Assert.False(object.ReferenceEquals(arr, newArr));
+            
+            // Original data should be copied, new elements should be default (0)
+            Assert.Equal(new int[] { 1, 2, 3, 0, 0 }, newArr);
+            
+            resizedArray.Dispose();
+        }
+        
+        [Fact]
+        public void Resize_WithEmptyArray_ShouldAllocateNewArray()
+        {
+            var pool = new ArrayPool<int>();
+            var emptyArray = pool.AllocateDisposable(0);
+            
+            // Resize empty array to size 3
+            var resizedArray = pool.Resize(emptyArray, 3);
+            int[] newArr = resizedArray;
+            
+            Assert.Equal(3, newArr.Length);
+            Assert.All(newArr, x => Assert.Equal(0, x)); // All elements should be default
+            
+            resizedArray.Dispose();
+        }
+        
+        [Fact]
+        public void Resize_ToZeroSize_ShouldReturnEmptyArray()
+        {
+            var pool = new ArrayPool<int>();
+            var originalArray = pool.AllocateDisposable(5);
+            
+            // Resize to zero size
+            var resizedArray = pool.Resize(originalArray, 0);
+            int[] newArr = resizedArray;
+            
+            Assert.Equal(0, newArr.Length);
+            
+            resizedArray.Dispose();
+        }
+    }
+}

--- a/csharp/Platform.Collections/Arrays/ArrayPool[T].cs
+++ b/csharp/Platform.Collections/Arrays/ArrayPool[T].cs
@@ -75,8 +75,13 @@ namespace Platform.Collections.Arrays
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Disposable<T[]> Resize(Disposable<T[]> source, long size)
         {
-            var destination = AllocateDisposable(size);
             T[] sourceArray = source;
+            if (!sourceArray.IsNullOrEmpty() && sourceArray.LongLength == size)
+            {
+                // If the size is the same, return the source without any allocation or copying
+                return source;
+            }
+            var destination = AllocateDisposable(size);
             if (!sourceArray.IsNullOrEmpty())
             {
                 T[] destinationArray = destination;

--- a/experiments/Experiments.csproj
+++ b/experiments/Experiments.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../csharp/Platform.Collections/Platform.Collections.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

This PR fixes the bug in the `ArrayPool<T>.Resize` method where resizing to the same size would unnecessarily:
- Allocate a new array from the pool
- Copy data from source to destination  
- Dispose the original array

## Changes Made

- **Fixed ArrayPool[T].cs:76-92**: Added early return optimization when `sourceArray.LongLength == size`
- **Added ArrayPoolTests.cs**: Comprehensive unit tests covering:
  - Same size resize (returns same object reference)
  - Different size resize (creates new object) 
  - Resize to larger size (copies data, fills with defaults)
  - Empty array resize
  - Resize to zero size

## Test Results

✅ All 25 tests pass (5 new + 20 existing)  
✅ No regressions introduced  
✅ Fix confirmed through reference equality checks

## Performance Impact

When resizing to the same size:
- **Before**: Always allocate + copy + dispose
- **After**: Simple reference return (O(1) instead of O(n))

Fixes #96

🤖 Generated with [Claude Code](https://claude.ai/code)