### PR TITLE
Rename SkipFirst method to Skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/79
+Your prepared branch: issue-79-70d192d0
+Your prepared working directory: /tmp/gh-issue-solver-1757795333893
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/79
-Your prepared branch: issue-79-70d192d0
-Your prepared working directory: /tmp/gh-issue-solver-1757795333893
-
-Proceed.

--- a/csharp/Platform.Collections/Lists/IListExtensions.cs
+++ b/csharp/Platform.Collections/Lists/IListExtensions.cs
@@ -425,7 +425,7 @@ namespace Platform.Collections.Lists
         /// <para>Если список пуст, возвращает пустой массив, иначе - массив с пропущенным первым элементом.</para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T[] SkipFirst<T>(this IList<T> list) => list.SkipFirst(1);
+        public static T[] Skip<T>(this IList<T> list) => list.Skip(1);
     
         /// <summary>
         /// <para>Skips the specified number of elements in the list and builds an array from the remaining elements.</para>
@@ -439,7 +439,7 @@ namespace Platform.Collections.Lists
         /// <para>Если список пуст, или количество пропускаемых элементов больше списка - возвращает пустой массив, иначе - массив с указанным количеством пропущенных элементов.</para>
         /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static T[] SkipFirst<T>(this IList<T> list, int skip)
+        public static T[] Skip<T>(this IList<T> list, int skip)
         {
             if (list.IsNullOrEmpty() || list.Count <= skip)
             {


### PR DESCRIPTION
## Summary
- Renamed `SkipFirst<T>()` method to `Skip<T>()` 
- Renamed `SkipFirst<T>(int skip)` method to `Skip<T>(int skip)`
- Both methods maintain the same functionality and signatures
- All tests pass successfully

## Test plan
- [x] Verified no existing usages of the renamed method in tests or other parts of the codebase
- [x] Confirmed all tests pass successfully after the rename
- [x] Verified the method signatures and functionality remain unchanged

Fixes #79

🤖 Generated with [Claude Code](https://claude.ai/code)