### PR TITLE
Add missing XML documentation comments to public classes and methods

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/75
-Your prepared branch: issue-75-c34824b4
-Your prepared working directory: /tmp/gh-issue-solver-1757805751102
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/75
+Your prepared branch: issue-75-c34824b4
+Your prepared working directory: /tmp/gh-issue-solver-1757805751102
+
+Proceed.

--- a/csharp/Platform.Collections/BitString.cs
+++ b/csharp/Platform.Collections/BitString.cs
@@ -12,6 +12,12 @@ using Platform.Ranges;
 
 namespace Platform.Collections
 {
+    /// <summary>
+    /// <para>
+    /// Represents a high-performance bit string with support for vectorized and parallel operations.
+    /// </para>
+    /// <para></para>
+    /// </summary>
     /// <remarks>
     /// А что если хранить карту значений, где каждый бит будет означать присутствует ли блок в 64 бит в массиве значений.
     /// 64 бита по 0 бит, будут означать отсутствие 64-х блоков по 64 бита. Т.е. упаковка 512 байт в 8 байт.

--- a/csharp/Platform.Collections/Segments/CharSegment.cs
+++ b/csharp/Platform.Collections/Segments/CharSegment.cs
@@ -110,6 +110,20 @@ namespace Platform.Collections.Segments
         /// </returns>
         public override bool Equals(object obj) => obj is Segment<char> charSegment ? Equals(charSegment) : false;
 
+        /// <summary>
+        /// <para>
+        /// Performs an implicit conversion from <see cref="CharSegment"/> to <see cref="string"/>.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        /// <param name="segment">
+        /// <para>The segment.</para>
+        /// <para></para>
+        /// </param>
+        /// <returns>
+        /// <para>The result of the conversion.</para>
+        /// <para></para>
+        /// </returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator string(CharSegment segment)
         {


### PR DESCRIPTION
## Summary
- Enhanced BitString class with proper summary documentation while preserving existing implementation notes
- Added XML documentation for implicit string conversion operator in CharSegment class
- Verified all public classes and methods in the Platform.Collections library now have complete XML documentation comments

## Test plan
- [x] Verified project builds successfully with no critical errors
- [x] Confirmed all public APIs have proper XML documentation following established patterns
- [x] Maintained consistency with existing bilingual documentation style where present

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #75