### PR TITLE
Add comprehensive performance benchmark comparing CharSegment and Segment<char>

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Collections/issues/56
+Your prepared branch: issue-56-e9dd2c77
+Your prepared working directory: /tmp/gh-issue-solver-1757823859092
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Collections/issues/56
-Your prepared branch: issue-56-e9dd2c77
-Your prepared working directory: /tmp/gh-issue-solver-1757823859092
-
-Proceed.

--- a/csharp/Platform.Collections.Benchmarks/Program.cs
+++ b/csharp/Platform.Collections.Benchmarks/Program.cs
@@ -4,6 +4,6 @@ namespace Platform.Collections.Benchmarks
 {
     static class Program
     {
-        static void Main() => BenchmarkRunner.Run<BitStringBenchmarks>();
+        static void Main() => BenchmarkRunner.Run<SegmentBenchmarks>();
     }
 }

--- a/csharp/Platform.Collections.Benchmarks/SegmentBenchmarks.cs
+++ b/csharp/Platform.Collections.Benchmarks/SegmentBenchmarks.cs
@@ -1,0 +1,155 @@
+using BenchmarkDotNet.Attributes;
+using Platform.Collections.Segments;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Platform.Collections.Benchmarks
+{
+    [SimpleJob]
+    [MemoryDiagnoser]
+    public class SegmentBenchmarks
+    {
+        [Params(10, 100, 1000, 10000)]
+        public int Length { get; set; }
+
+        private char[] _data = null!;
+        private CharSegment _charSegment = null!;
+        private Segment<char> _segment = null!;
+        private string _testString = null!;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var random = new System.Random(42); // Fixed seed for reproducible results
+            _data = new char[Length * 2]; // Make it larger to test different offsets
+            
+            // Fill with random characters
+            for (int i = 0; i < _data.Length; i++)
+            {
+                _data[i] = (char)('a' + random.Next(26));
+            }
+
+            int offset = Length / 4; // Use some offset to test realistic scenarios
+            
+            _charSegment = new CharSegment(_data, offset, Length);
+            _segment = new Segment<char>(_data, offset, Length);
+            _testString = new string(_data, offset, Length);
+        }
+
+        [Benchmark]
+        public int CharSegmentGetHashCode() => _charSegment.GetHashCode();
+
+        [Benchmark]
+        public int SegmentGetHashCode() => _segment.GetHashCode();
+
+        [Benchmark]
+        public bool CharSegmentEqualsItself() => _charSegment.Equals(_charSegment);
+
+        [Benchmark]
+        public bool SegmentEqualsItself() => _segment.Equals(_segment);
+
+        [Benchmark]
+        public bool CharSegmentEqualsOther()
+        {
+            var other = new CharSegment(_data, _charSegment.Offset, _charSegment.Length);
+            return _charSegment.Equals(other);
+        }
+
+        [Benchmark]
+        public bool SegmentEqualsOther()
+        {
+            var other = new Segment<char>(_data, _segment.Offset, _segment.Length);
+            return _segment.Equals(other);
+        }
+
+        [Benchmark]
+        public char CharSegmentIndexAccess()
+        {
+            char result = '\0';
+            for (int i = 0; i < _charSegment.Count; i++)
+            {
+                result ^= _charSegment[i];
+            }
+            return result;
+        }
+
+        [Benchmark]
+        public char SegmentIndexAccess()
+        {
+            char result = '\0';
+            for (int i = 0; i < _segment.Count; i++)
+            {
+                result ^= _segment[i];
+            }
+            return result;
+        }
+
+        [Benchmark]
+        public string CharSegmentToString() => _charSegment.ToString();
+
+        [Benchmark]
+        public string SegmentToString() => _segment.ToString() ?? string.Empty;
+
+        [Benchmark]
+        public string CharSegmentImplicitConversion() => _charSegment;
+
+        [Benchmark]
+        public bool CharSegmentContains()
+        {
+            char searchChar = _data[_charSegment.Offset + _charSegment.Length / 2];
+            return _charSegment.Contains(searchChar);
+        }
+
+        [Benchmark]
+        public bool SegmentContains()
+        {
+            char searchChar = _data[_segment.Offset + _segment.Length / 2];
+            return _segment.Contains(searchChar);
+        }
+
+        [Benchmark]
+        public int CharSegmentIndexOf()
+        {
+            char searchChar = _data[_charSegment.Offset + _charSegment.Length / 2];
+            return _charSegment.IndexOf(searchChar);
+        }
+
+        [Benchmark]
+        public int SegmentIndexOf()
+        {
+            char searchChar = _data[_segment.Offset + _segment.Length / 2];
+            return _segment.IndexOf(searchChar);
+        }
+
+        [Benchmark]
+        public char[] CharSegmentToArray() => _charSegment.ToArray();
+
+        [Benchmark]
+        public char[] SegmentToArray() => _segment.ToArray();
+
+        [Benchmark]
+        public List<char> CharSegmentToList() => _charSegment.ToList();
+
+        [Benchmark]
+        public List<char> SegmentToList() => _segment.ToList();
+
+        [Benchmark]
+        public void CharSegmentForeachIteration()
+        {
+            foreach (var c in _charSegment)
+            {
+                // Empty loop to measure iteration overhead
+            }
+        }
+
+        [Benchmark]
+        public void SegmentForeachIteration()
+        {
+            foreach (var c in _segment)
+            {
+                // Empty loop to measure iteration overhead
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🎯 Summary

This pull request implements a comprehensive benchmark suite to compare the performance of `CharSegment` and `Segment<char>` as requested in issue #56.

## 📋 Issue Reference
Fixes #56

## 🚀 Implementation Details

### Added SegmentBenchmarks.cs
A complete benchmark class that compares performance across multiple operations:

- **Hash Code Generation**: `GetHashCode()` performance comparison
- **Equality Comparison**: Both self-equality and cross-instance equality tests  
- **Index Access**: Element access via indexer `[i]` performance
- **String Conversion**: `ToString()` and implicit string conversion performance
- **Search Operations**: `Contains()` and `IndexOf()` method performance
- **Collection Conversion**: `ToArray()` and `ToList()` performance
- **Iteration**: `foreach` loop iteration performance

### Benchmark Configuration
- Uses BenchmarkDotNet with SimpleJob and MemoryDiagnoser
- Tests multiple data sizes: 10, 100, 1000, 10000 elements
- Fixed random seed (42) for reproducible results
- Tests realistic scenarios with offset segments

### Updated Program.cs
Modified the benchmark runner to execute the new `SegmentBenchmarks` instead of `BitStringBenchmarks`.

## 🧪 Test Coverage

The benchmark suite provides comprehensive performance analysis to help identify:
1. Which implementation is faster for specific operations
2. Memory allocation patterns via MemoryDiagnoser
3. Performance scaling across different data sizes
4. Optimization opportunities for both classes

## 🏃‍♂️ How to Run

```bash
cd csharp/Platform.Collections.Benchmarks
dotnet run -c Release
```

## 📊 Expected Insights

This benchmark will help determine:
- Whether CharSegment's specialized char[] optimizations provide measurable benefits
- Performance differences in hash code calculation and equality checking
- String conversion performance (implicit conversion vs ToString())
- Memory allocation differences between the implementations

---
🤖 Generated with [Claude Code](https://claude.ai/code)